### PR TITLE
removed matchparen from lazy_nvim.lua

### DIFF
--- a/lua/plugins/configs/lazy_nvim.lua
+++ b/lua/plugins/configs/lazy_nvim.lua
@@ -22,7 +22,6 @@ return {
         "health",
         "man",
         "matchit",
-        "matchparen",
         "rplugin",
         "tarPlugin",
         "tohtml",


### PR DESCRIPTION
don't disable `matchparen` this is very useful inbuilt plugin